### PR TITLE
Updated index.md - linux ahoy v2 install example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,8 @@ Download and unzip the latest release and move the appropriate binary for your p
 Example:
 ```
 sudo wget -q https://github.com/ahoy-cli/ahoy/releases/download/1.1.0/ahoy-`uname -s`-amd64 -O /usr/local/bin/ahoy && sudo chown $USER /usr/local/bin/ahoy && chmod +x /usr/local/bin/ahoy
+# For v2
+sudo wget -q https://github.com/ahoy-cli/ahoy/releases/download/2.0.0/ahoy-bin-`uname -s`-amd64 -O /usr/local/bin/ahoy && sudo chown $USER /usr/local/bin/ahoy && chmod +x /usr/local/bin/ahoy
 ```
 
 ### Bash / Zsh Completion


### PR DESCRIPTION
Added an example of how to install ahoy v2 on Linux to match the installation instructions for OSX