### PR TITLE
fix!: [#4] Show overwrite warning for `ahoy init`

### DIFF
--- a/ahoy.go
+++ b/ahoy.go
@@ -112,14 +112,14 @@ func getConfig(file string) (Config, error) {
 		return config, err
 	}
 
-	// Extract the yaml file into the config varaible.
+	// Extract the yaml file into the config variable.
 	err = yaml.Unmarshal(yamlFile, &config)
 	if err != nil {
 		return config, err
 	}
 
 	// All ahoy files (and imports) must specify the ahoy version.
-	// This is so we can support backwards compatability in the future.
+	// This is so we can support backwards compatibility in the future.
 	if config.AhoyAPI != "v2" {
 		err = errors.New("Ahoy only supports API version 'v2', but '" + config.AhoyAPI + "' given in " + sourcefile)
 		return config, err
@@ -146,8 +146,8 @@ func getSubCommands(includes []string) []cli.Command {
 			include = filepath.Join(AhoyConf.srcDir, include)
 		}
 		if _, err := os.Stat(include); err != nil {
-			//Skipping files that cannot be loaded allows us to separate
-			//subcommands into public and private.
+			// Skipping files that cannot be loaded allows us to separate
+			// subcommands into public and private.
 			continue
 		}
 		config, _ := getConfig(include)

--- a/ahoy_test.go
+++ b/ahoy_test.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -23,7 +24,7 @@ func TestGetCommands(t *testing.T) {
 		Usage:   "Test getSubCommands Usage.",
 		AhoyAPI: "v2",
 		Commands: map[string]Command{
-			"test-command": Command{
+			"test-command": {
 				Description: "Testing example Command.",
 				Usage:       "test-command a",
 				Cmd:         "echo a.ahoy.yml",
@@ -169,7 +170,7 @@ func TestGetConfig(t *testing.T) {
 		Usage:   "Test example usage.",
 		AhoyAPI: "v2",
 		Commands: map[string]Command{
-			"test-command": Command{
+			"test-command": {
 				Description: "Testing example Command.",
 				Usage:       "test-command",
 				Cmd:         "echo 'Hello World'",
@@ -184,7 +185,7 @@ func TestGetConfig(t *testing.T) {
 	testYaml, err := yaml.Marshal(expected)
 
 	if err != nil {
-		t.Error("Something went wrong mashelling the test object.")
+		t.Error("Something went wrong mashalling the test object.")
 	}
 
 	testFile.Write([]byte(testYaml))
@@ -210,14 +211,14 @@ func TestGetConfig(t *testing.T) {
 func TestGetConfigPath(t *testing.T) {
 	// Passinng empty string.
 	pwd, _ := os.Getwd()
-	expected := pwd + "/.ahoy.yml"
+	expected := filepath.Join(pwd, ".ahoy.yml")
 	actual, _ := getConfigPath("")
 	if expected != actual {
 		t.Errorf("ahoy docker override-example: expected - %s; actual - %s", string(expected), string(actual))
 	}
 
 	// Passing known path works as expected
-	expected = pwd + "/.ahoy.yml"
+	expected = filepath.Join(pwd, ".ahoy.yml")
 	actual, _ = getConfigPath(expected)
 
 	if expected != actual {
@@ -244,7 +245,7 @@ func appRun(args []string) (string, error) {
 
 	w.Close()
 	//@aashil thinks this reads from the command line
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	os.Stdout = stdout
 	return string(out), nil
 }

--- a/tests/no-ahoy-file.bats
+++ b/tests/no-ahoy-file.bats
@@ -27,7 +27,8 @@ teardown() {
 
 @test "run ahoy init with a existing .ahoy.yml file in the current directory" {
   cp tmp.ahoy.yml .ahoy.yml
-  run ./ahoy init
-  [ "${lines[-1]}" == "Warning: .ahoy.yml found in current directory." ]
+  run ./ahoy init --force
+  [ "${lines[0]}" == "Warning: '--force' parameter passed, overwriting .ahoy.yml in current directory." ]
+  [ "${lines[-1]}" == "Example .ahoy.yml downloaded to the current directory. You can customize it to suit your needs!" ]
   rm .ahoy.yml
 }

--- a/tests/no-ahoy-file.bats
+++ b/tests/no-ahoy-file.bats
@@ -22,5 +22,12 @@ teardown() {
 
 @test "run ahoy init without a .ahoy.yml file" {
   run ./ahoy init
-  [ "${lines[-1]}" == "example.ahoy.yml downloaded to the current directory. You can customize it to suit your needs!" ]
+  [ "${lines[-1]}" == "Example .ahoy.yml downloaded to the current directory. You can customize it to suit your needs!" ]
+}
+
+@test "run ahoy init with a existing .ahoy.yml file in the current directory" {
+  cp tmp.ahoy.yml .ahoy.yml
+  run ./ahoy init
+  [ "${lines[-1]}" == "Warning: .ahoy.yml found in current directory." ]
+  rm .ahoy.yml
 }


### PR DESCRIPTION
Fix for #4 

Shows a warning and a confirmation prompt when running `ahoy init`
if an `.ahoy.yml` file already exists in the current directory and
would otherwise be overwritten.

BREAKING CHANGE: The warning prompt requires user input, so this may
require updating of e.g. scripted calls to `ahoy init`. The prompt
can be overruled by passing the "force" flag, e.g.
`ahoy init --force`

If the `--force` flag is passed, the `init` command goes ahead, but a warning message is still shown:

"Warning: '--force' parameter passed, overwriting .ahoy.yml in current directory.".