### PR TITLE
chore: Realign binary naming & ldflags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,13 @@ jobs:
           name: Install BATS.
           command: git clone https://github.com/bats-core/bats-core.git && cd bats-core && sudo ./install.sh /usr/local && bats --version && cd -
       - run:
+          name: Install BATS extras.
+          command: |
+            cd tests
+            git clone https://github.com/bats-core/bats-support.git ./test_helpers/bats-support
+            git clone https://github.com/bats-core/bats-assert.git ./test_helpers/bats-assert
+            cd -
+      - run:
           name: Install Go linter.
           command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
       - run:

--- a/tests/cross-compile.bats
+++ b/tests/cross-compile.bats
@@ -1,23 +1,31 @@
 #!/usr/bin/env bats
 
-load './test_helpers/bats-support/load'
-load './test_helpers/bats-assert/load'
+load 'test_helpers/bats-support/load'
+load 'test_helpers/bats-assert/load'
 
-@test "clean out any cross compiled binaries" {
+@test "test cross compilation command lifecycle" {
   run make clean
   assert_success
   assert_output --partial 'rm -vRf ./builds/ahoy-bin-*'
-}
 
-@test "cross compile binaries with make" {
+  run ls ./builds/ahoy-*
+  assert_failure
+  assert_output --partial 'No such file'
+
   run make cross
   assert_success
   assert_output --partial 'mv ./builds/ahoy-bin-windows-amd64 ./builds/ahoy-bin-windows-amd64.exe; mv ./builds/ahoy-bin-windows-arm64 ./builds/ahoy-bin-windows-arm64.exe;'
-}
 
-@test "check cross compiled binaries exist" {
   run ls ./builds/ahoy-*
   assert_output --partial 'ahoy-bin-darwin-amd64'
   assert_output --partial 'ahoy-bin-linux-arm64'
   assert_output --partial 'ahoy-bin-windows-amd64.exe'
+
+  run make clean
+  assert_success
+  assert_output --partial 'rm -vRf ./builds/ahoy-bin-*'
+
+  run ls ./builds/ahoy-*
+  assert_failure
+  assert_output --partial 'No such file'
 }

--- a/tests/cross-compile.bats
+++ b/tests/cross-compile.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+load './test_helpers/bats-support/load'
+load './test_helpers/bats-assert/load'
+
+@test "clean out any cross compiled binaries" {
+  run make clean
+  assert_success
+  assert_output --partial 'rm -vRf ./builds/ahoy-bin-*'
+}
+
+@test "cross compile binaries with make" {
+  run make cross
+  assert_success
+  assert_output --partial 'mv ./builds/ahoy-bin-windows-amd64 ./builds/ahoy-bin-windows-amd64.exe; mv ./builds/ahoy-bin-windows-arm64 ./builds/ahoy-bin-windows-arm64.exe;'
+}
+
+@test "check cross compiled binaries exist" {
+  run ls ./builds/ahoy-*
+  assert_output --partial 'ahoy-bin-darwin-amd64'
+  assert_output --partial 'ahoy-bin-linux-arm64'
+  assert_output --partial 'ahoy-bin-windows-amd64.exe'
+}


### PR DESCRIPTION
Bring binary naming in Makefile in line with previous releases
(i.e. make a bare binary, named with suffixes, not in a tar.gz file).

Use Makefile foreach to reduce repetition.

Make `ldflags` more similar to Homebrew Go standard `ldflags` so
binaries downloaded from GH or built with Homebrew are more
closely aligned.