### PR TITLE
[Fix] Broken installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Download the [latest release from GitHub](https://github.com/ahoy-cli/ahoy/relea
 
 Example:
 ```
-os=$(uname -s | tr [:upper:] [:lower:]) && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) && sudo wget -q https://github.com/ahoy-cli/ahoy/releases/latest/download/ahoy-bin-$os-$architecture -O /usr/local/bin/ahoy && sudo chown $USER /usr/local/bin/ahoy && chmod +x /usr/local/bin/ahoy
+os=$(uname -s | tr '[:upper:]' '[:lower:]') && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) && sudo wget -q https://github.com/ahoy-cli/ahoy/releases/latest/download/ahoy-bin-$os-$architecture -O /usr/local/bin/ahoy && sudo chown $USER /usr/local/bin/ahoy && chmod +x /usr/local/bin/ahoy
 ```
 
 ### Windows


### PR DESCRIPTION
The one-line installation command in the README is currently broken.

When run on mac, attempting to run the command results in the error `zsh: no matches found: [:upper:]`.

This is because `tr` requires the `[:upper:]` and `[:lower:]` to be surrounded by apostraphes. See https://stackoverflow.com/a/2264537

This PR fixes this issue.