### PR TITLE
[Fix] Update Zsh completions and add Oh-My-Zsh plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 docs/_build
 # Ignore the ahoy binary when it's built
 ahoy
+!autocompletions/zsh/ahoy
+
 .idea
 builds/*
 

--- a/autocompletions/zsh/ahoy-zsh-autocomplete
+++ b/autocompletions/zsh/ahoy-zsh-autocomplete
@@ -1,0 +1,23 @@
+#compdef ahoy
+
+_ahoy() {
+
+  local -a opts
+  local cur
+  cur=${words[-1]}
+  if [[ "$cur" == "-"* ]]; then
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+  else
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+  fi
+
+  if [[ "${opts[1]}" != "" ]]; then
+    _describe 'values' opts
+  else
+    _files
+  fi
+
+  return
+}
+
+compdef _ahoy ahoy

--- a/autocompletions/zsh/ahoy/README.md
+++ b/autocompletions/zsh/ahoy/README.md
@@ -1,3 +1,18 @@
 # Ahoy Oh-My-Zsh plugin
 
-Add this plugin to your custom oh-My-Zsh plugins folder and then enable it in your `.zshrc`.
+1. Clone the zsh-ahoy repository into `$ZSH_CUSTOM/plugins` (by default `~/.oh-my-zsh/custom/plugins`)
+
+```bash
+git clone https://github.com/ahoy-cli/zsh-ahoy ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/ahoy
+```
+
+2. Add the ahoy zsh plugin to the list of plugins for Oh My Zsh to load, inside `~/.zshrc`:
+
+```
+plugins=(
+    # Other plugins above...
+    ahoy
+)
+```
+
+3. Start a new terminal session.

--- a/autocompletions/zsh/ahoy/README.md
+++ b/autocompletions/zsh/ahoy/README.md
@@ -1,9 +1,9 @@
 # Ahoy Oh-My-Zsh plugin
 
-1. Clone the zsh-ahoy repository into `$ZSH_CUSTOM/plugins` (by default `~/.oh-my-zsh/custom/plugins`)
+1. Copy this folder into the `$ZSH_CUSTOM/plugins` directory (by default `~/.oh-my-zsh/custom/plugins`). The command below is being run from the perspective of this directory.
 
 ```bash
-git clone https://github.com/ahoy-cli/zsh-ahoy ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/ahoy
+cp -r ../ahoy ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/ahoy
 ```
 
 2. Add the ahoy zsh plugin to the list of plugins for Oh My Zsh to load, inside `~/.zshrc`:

--- a/autocompletions/zsh/ahoy/README.md
+++ b/autocompletions/zsh/ahoy/README.md
@@ -1,0 +1,3 @@
+# Ahoy Oh-My-Zsh plugin
+
+Add this plugin to your custom oh-My-Zsh plugins folder and then enable it in your `.zshrc`.

--- a/autocompletions/zsh/ahoy/_ahoy
+++ b/autocompletions/zsh/ahoy/_ahoy
@@ -1,0 +1,23 @@
+#compdef ahoy
+
+_ahoy() {
+
+  local -a opts
+  local cur
+  cur=${words[-1]}
+  if [[ "$cur" == "-"* ]]; then
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+  else
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+  fi
+
+  if [[ "${opts[1]}" != "" ]]; then
+    _describe 'values' opts
+  else
+    _files
+  fi
+
+  return
+}
+
+_ahoy "$@"

--- a/autocompletions/zsh/ahoy/ahoy.plugin.zsh
+++ b/autocompletions/zsh/ahoy/ahoy.plugin.zsh
@@ -1,0 +1,17 @@
+alias ah='ahoy'
+
+# Exit early if ahoy plugin is already loaded.
+if (( ${+commands[ahoy]} )); then
+    return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `ahoy`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_ahoy" ]]; then
+    typeset -g -A _comps
+    autoload -Uz _ahoy
+    _comps[ahoy]=_ahoy
+fi
+
+# Save completions file in cache directory. 
+cp "${0:h}/_ahoy" "$ZSH_CACHE_DIR/completions/_ahoy"

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,9 +55,21 @@ sudo wget -q https://github.com/ahoy-cli/ahoy/releases/download/2.0.0/ahoy-bin-`
 ```
 
 ### Bash / Zsh Completion
-For Zsh, Just add this to your ~/.zshrc, and your completions will be relative to the directory you're in.
+For Zsh, there are two options. If you are using Oh-My-Zsh, you can install our custom plugin by downloading the `autocomplete/zsh/ahoy` folder and placing it in the Oh-My-Zsh custom plugin folder,
+usually located at `~/.oh-my-zsh/custom/plugin`. Then you must enable it in your `./zshrc`:
 
-`complete -F "ahoy --generate-bash-completion" ahoy`
+```
+plugins=(
+    # other plugins...
+    ahoy
+)
+
+```
+Alternatively, if you don't use Oh-My-Zsh you can save the `autocomplete/zsh/ahoy-zsh-autocomplete` file somewhere and source it in your `~/.zshrc`:
+
+```
+source /path/to/ahoy-zsh-autocomplete
+```
 
 For Bash, you'll need to make sure you have bash-completion installed and setup. On OSX with homebrew it looks like this:
 


### PR DESCRIPTION
The ZSH completions (as they are currently documented) are broken.

This PR uses the correct autocompletion script, taken upstream from [urfave/cli](https://github.com/urfave/cli/blob/v1.22.16/autocomplete/zsh_autocomplete) (Note the urfave/cli/v1 version, since thats what `ahoy` currently uses).

I think a better solution ultimately will be to create a new `ahoy-cli/zsh-ahoy` that is especially designed to house the autocompletion functionality, including the Oh-My-Zsh custom plugin that I have written (c.f [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions)).

