### PR TITLE
Added BATS coverage for verbose flag positions and arg passthru.

### DIFF
--- a/tests/verbose-flag.bats
+++ b/tests/verbose-flag.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+# Verbose flag positioning tests.
+#
+# Cobra's persistent flag handler accepts the verbose flag anywhere relative
+# to the subcommand name and its positional arguments. The legacy single-dash
+# pre-parser (flag.go) handles the case where the flag appears before the
+# subcommand; everything else is delegated to cobra. These tests pin that
+# contract and verify that command arguments still reach the underlying
+# command without requiring a '--' separator.
+
+@test "Verbose: no flag means no debug output" {
+  run ./ahoy -f testdata/simple.ahoy.yml echo hello
+  [ $status -eq 0 ]
+  [[ "$output" != *"===> Ahoy"* ]]
+  [ "$output" = "hello" ]
+}
+
+@test "Verbose: -v before command enables debug output" {
+  run ./ahoy -v -f testdata/simple.ahoy.yml echo hello
+  [ $status -eq 0 ]
+  [[ "$output" == *"===> Ahoy echo"* ]]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "Verbose: --verbose before command enables debug output" {
+  run ./ahoy --verbose -f testdata/simple.ahoy.yml echo hello
+  [ $status -eq 0 ]
+  [[ "$output" == *"===> Ahoy echo"* ]]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "Verbose: -v after command enables debug output" {
+  run ./ahoy -f testdata/simple.ahoy.yml echo -v hello
+  [ $status -eq 0 ]
+  [[ "$output" == *"===> Ahoy echo"* ]]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "Verbose: --verbose after command enables debug output" {
+  run ./ahoy -f testdata/simple.ahoy.yml echo --verbose hello
+  [ $status -eq 0 ]
+  [[ "$output" == *"===> Ahoy echo"* ]]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "Verbose: -v interspersed between args sets verbose and preserves args" {
+  run ./ahoy -f testdata/simple.ahoy.yml echo one -v two
+  [ $status -eq 0 ]
+  [[ "$output" == *"===> Ahoy echo"* ]]
+  [[ "$output" == *"one two"* ]]
+}
+
+@test "Args passthru: multiple positional args reach command without '--'" {
+  run ./ahoy -f testdata/simple.ahoy.yml echo first second third
+  [ $status -eq 0 ]
+  [ "$output" = "first second third" ]
+}
+
+@test "Args passthru: '--' separator passes -v as a literal argument" {
+  run ./ahoy -f testdata/simple.ahoy.yml echo -- -v
+  [ $status -eq 0 ]
+  [[ "$output" != *"===> Ahoy"* ]]
+  [ "$output" = "-v" ]
+}
+
+@test "Args passthru: '--' passes verbose-like args through verbatim" {
+  run ./ahoy -f testdata/simple.ahoy.yml echo -- hello --verbose world
+  [ $status -eq 0 ]
+  [[ "$output" != *"===> Ahoy"* ]]
+  [ "$output" = "hello --verbose world" ]
+}
+
+@test "Verbose: AHOY_VERBOSE env var enables debug output" {
+  AHOY_VERBOSE=true run ./ahoy -f testdata/simple.ahoy.yml echo hello
+  [ $status -eq 0 ]
+  [[ "$output" == *"===> Ahoy echo"* ]]
+  [[ "$output" == *"hello"* ]]
+}


### PR DESCRIPTION
## Summary

- Added `tests/verbose-flag.bats` with 10 new BATS tests covering verbose flag positioning and positional argument passthrough.
- Tests pin the contract that Cobra's persistent flag handler accepts `-v` / `--verbose` anywhere relative to the subcommand and its arguments (before the command, after the command, interspersed with positional args), and that the legacy single-dash pre-parser in `flag.go` handles the case where `-v` appears before the subcommand name.
- Tests also verify that positional arguments reach the underlying command without requiring a `--` separator, and that a literal `--` correctly passes flag-like strings (e.g. `-v`, `--verbose`) through as plain arguments rather than activating verbose mode.

## Test plan

- [ ] `go build -o ./ahoy .` completes without errors.
- [ ] `go vet ./...` reports no issues.
- [ ] `go test -v -race ./...` passes all unit tests.
- [ ] `bats tests` runs all BATS tests (125 total, including the 10 new ones) and all pass.
- [ ] Spot-check: run `./ahoy -f tests/testdata/simple.ahoy.yml echo -v hello` and confirm the `===> Ahoy echo` header appears.
- [ ] Spot-check: run `./ahoy -f tests/testdata/simple.ahoy.yml echo -- -v` and confirm output is literally `-v` with no debug header.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for verbose flag functionality, including support for different flag positions, argument forwarding, and environment variable configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ahoy-cli/ahoy/pull/169)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->