### PR TITLE
fix: Update to latest Go 1.26 version for CI tests and builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache: true
 
       - name: Install BATS (Linux/macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.22.x"
+          go-version: "1.26.x"
           cache-dependency-path: v2/go.sum
           # Disabled to avoid cache-poisoning of release artefacts (zizmor).
           cache: false

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ahoy-cli/ahoy/v3
 
 go 1.23.0
 
-toolchain go1.24.7
+toolchain go1.26.4
 
 require (
 	github.com/spf13/cobra v1.10.1

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -2,7 +2,7 @@ module github.com/ahoy-cli/ahoy/v2
 
 go 1.23
 
-toolchain go1.24.5
+toolchain go1.26.4
 
 require (
 	github.com/urfave/cli v1.22.9


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project and release pipelines to use Go 1.26.
  * Aligned the module toolchain configuration with the newer Go version for more consistent builds and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->